### PR TITLE
Fix for removal of old migration for CustomInput ConsumingType values

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -1,17 +1,15 @@
 require "styles"
 
 data:extend(
-	{	
+	{
 		{
 			type = "custom-input",
 			name = "ACT_IPS_IPM",
 			key_sequence = "CONTROL + ALT + T",
-			consuming = "script-only"
-			-- 'consuming' available options:
-			-- none: default if not defined
-			-- all: if this is the first input to get this key sequence then no other inputs listening for this sequence are fired
-			-- script-only: if this is the first *custom* input to get this key sequence then no other *custom* inputs listening for this sequence are fired. Normal game inputs will still be fired even if they match this sequence.
-			-- game-only: The opposite of script-only: blocks game inputs using the same key sequence but lets other custom inputs using the same key sequence fire.
+			consuming = "none"
+			-- Reference:
+			-- - https://forums.factorio.com/viewtopic.php?p=492101#p492101
+			-- - https://wiki.factorio.com/Types/ConsumingType
 	  },
 	}
 )


### PR DESCRIPTION
Addresses issue #10 

Breaking mod change post here: https://forums.factorio.com/viewtopic.php?p=492101#p492101

Basically, old ConsumingPrototype migrations were removed.