### PR TITLE
Fixed productivty bonus for miners, and added recipe execution cap by…

### DIFF
--- a/locale/en/en.cfg
+++ b/locale/en/en.cfg
@@ -42,6 +42,7 @@ minutes=__1__ minutes
 perSec=/sec
 perMin=/min
 longSeconds=__1__ crafts in __2__
+is-capped=[color=red]Capped: All recipes can be executed only once per tick.[/color]
 
 recipe_label=Recipe
 belt=Belt


### PR DESCRIPTION
… tick

1. Fixed productivty bonus for miners
Now the productivity bonuses from module and research are added, not multiplied.

2. Added recipe execution cap by tick
All recipes can be executed once per tick. So made it to show capped result and display warning message for that.
But productivity bonus is not affected by tick, and also it is not capped by the  capped ingredient input. That means high productivity + high speed gives us just free products.
(https://imgur.com/a/ANV83aC)

* Version number should to be incresed after pulling this patch.